### PR TITLE
이동봉사 화면에 아키텍쳐를 적용했습니다.

### DIFF
--- a/app/src/main/java/com/teamtriad/forpets/ui/MainActivity.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/MainActivity.kt
@@ -2,6 +2,7 @@ package com.teamtriad.forpets.ui
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
@@ -9,6 +10,7 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.teamtriad.forpets.R
 import com.teamtriad.forpets.databinding.ActivityMainBinding
+import com.teamtriad.forpets.viewmodel.TransportViewModel
 
 class MainActivity : AppCompatActivity() {
 
@@ -16,6 +18,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var navController: NavController
 
+    private val viewModel: TransportViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -37,6 +40,9 @@ class MainActivity : AppCompatActivity() {
 
         hideAppBar()
         hideBottomNavigationView()
+
+        viewModel.getAllLocationMap()
+        viewModel.getAllTransportReqMap()
 
     }
 

--- a/app/src/main/java/com/teamtriad/forpets/ui/MainActivity.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/MainActivity.kt
@@ -40,10 +40,6 @@ class MainActivity : AppCompatActivity() {
 
         hideAppBar()
         hideBottomNavigationView()
-
-        viewModel.getAllLocationMap()
-        viewModel.getAllTransportReqMap()
-
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
@@ -105,7 +105,7 @@ class TransportFragment : Fragment() {
 
             setOnClusterItemClickListener {
                 val zoomLevel = map.cameraPosition.zoom
-                if (zoomLevel == 13f) {
+                if (zoomLevel >= 13f) {
                     if (segmentedButtonId == R.id.btn_request) {
                         viewModel.setClickedFrom(it.snippet)
 

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
@@ -44,7 +44,7 @@ class TransportFragment : Fragment(), OnMapReadyCallback {
         super.onViewCreated(view, savedInstanceState)
         setMapFragment()
         setOnClickListeners()
-        viewModel.getAllCountyMap()
+        viewModel.getAllLocationMap()
     }
 
     private fun setMapFragment() {

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/TransportFragment.kt
@@ -135,8 +135,14 @@ class TransportFragment : Fragment() {
             }
 
             setOnClusterItemClickListener {
+                val zoomLevel = map.cameraPosition.zoom
+                if(zoomLevel == 13f) {
+                    findNavController().navigate(R.id.action_transportFragment_to_transportListsFragment)
+                }
+
                 map.moveCamera(CameraUpdateFactory.newLatLngZoom(it.position, 13f))
                 map.moveCamera(CameraUpdateFactory.newLatLng(it.position))
+
                 true
             }
         }

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/ViewPagerReqListFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/ViewPagerReqListFragment.kt
@@ -49,15 +49,21 @@ class ViewPagerReqListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        transportViewModel.clearAllSelectedLocations()
-
         dateRangePicker = setDatePicker()
 
-        if (transportViewModel.reqAnimalChoice.isEmpty()) {
-            transportViewModel.setReqAnimalChoice(
-                resources.getStringArray(R.array.req_animal_choice)
-                    .toList()
-            )
+        with(transportViewModel) {
+            if (reqAnimalChoice.isEmpty()) {
+                setReqAnimalChoice(resources.getStringArray(R.array.req_animal_choice).toList())
+            }
+
+            clearAllSelectedLocations()
+
+            if (clickedFrom != null) {
+                setSelectedFromCounty(clickedFrom!!.substring(0, clickedFrom!!.indexOf(' ')))
+                setSelectedFromDistrict(clickedFrom!!.substring(clickedFrom!!.indexOf(' ') + 1))
+
+                setClickedFrom(null)
+            }
         }
 
         with(binding) {

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/Item.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/Item.kt
@@ -1,11 +1,10 @@
 package com.teamtriad.forpets.ui.transport.marker
 
-import com.google.android.gms.maps.model.LatLng
-
 data class Item(
     val title: String,
     val county: String,
     val district: String,
     val uid: String,
-    val place: LatLng,
+    var lat: Double,
+    var lng: Double,
 )

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/Item.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/Item.kt
@@ -1,0 +1,11 @@
+package com.teamtriad.forpets.ui.transport.marker
+
+import com.google.android.gms.maps.model.LatLng
+
+data class Item(
+    val title: String,
+    val county: String,
+    val district: String,
+    val uid: String,
+    val place: LatLng,
+)

--- a/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/MarkerItem.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/transport/marker/MarkerItem.kt
@@ -22,7 +22,7 @@ class MarkerItem(
     override fun getZIndex(): Float = 0f
 
     init {
-        position = place
+        this.position = place
         this.title = title
         this.snippet = snippet
     }

--- a/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
+++ b/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
@@ -41,6 +41,9 @@ class TransportViewModel : ViewModel() {
     private var _movingMap = MutableLiveData<Map<String, Moving>>()
     val movingMap: LiveData<Map<String, Moving>> get() = _movingMap
 
+    private var _clickedFrom: String? = null
+    val clickedFrom: String? get() = _clickedFrom
+
     private var _reqAnimalChoice = listOf<String>()
     val reqAnimalChoice: List<String> get() = _reqAnimalChoice
 
@@ -246,6 +249,10 @@ class TransportViewModel : ViewModel() {
         return userRepository.getUserNicknameByUid(uid)
     }
 
+    fun setClickedFrom(from: String?) {
+        _clickedFrom = from
+    }
+
     fun setReqAnimalChoice(reqAnimalChoice: List<String>) {
         _reqAnimalChoice = reqAnimalChoice
     }
@@ -291,9 +298,9 @@ class TransportViewModel : ViewModel() {
         to: String
     ): List<TransportReq> {
         fun compareWithDates(s: String, e: String) = startDate.isEmpty() ||
-            s <= endDate && startDate <= e
+                s <= endDate && startDate <= e
         fun compareWithAnimal(s: String) = animal.isEmpty() || s == animal ||
-            animal == reqAnimalChoice.last() && s !in reqAnimalChoice.subList(0, reqAnimalChoice.lastIndex)
+                animal == reqAnimalChoice.last() && s !in reqAnimalChoice.subList(0, reqAnimalChoice.lastIndex)
         fun compareWithFrom(s: String) = from.isEmpty() || s == from
         fun compareWithTo(s: String) = to.isEmpty() || s == to
 

--- a/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
+++ b/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
@@ -16,6 +16,7 @@ import com.teamtriad.forpets.data.source.network.model.Moving
 import com.teamtriad.forpets.data.source.network.model.TransportReq
 import com.teamtriad.forpets.data.source.network.model.TransportVol
 import com.teamtriad.forpets.ui.chat.enums.AppointmentProgress
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 class TransportViewModel : ViewModel() {
@@ -157,10 +158,8 @@ class TransportViewModel : ViewModel() {
     /**
      * 등록된 시/도들의 목록을 전부 가져옵니다.(LiveData)
      */
-    fun getAllLocationMap() {
-        viewModelScope.launch {
-            _locationMap.value = locationRepository.getAllCountyMap() ?: mapOf()
-        }
+    fun getAllLocationMap(): Job = viewModelScope.launch {
+        _locationMap.value = locationRepository.getAllCountyMap() ?: mapOf()
     }
 
     /**

--- a/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
+++ b/app/src/main/java/com/teamtriad/forpets/viewmodel/TransportViewModel.kt
@@ -157,7 +157,7 @@ class TransportViewModel : ViewModel() {
     /**
      * 등록된 시/도들의 목록을 전부 가져옵니다.(LiveData)
      */
-    fun getAllCountyMap() {
+    fun getAllLocationMap() {
         viewModelScope.launch {
             _locationMap.value = locationRepository.getAllCountyMap() ?: mapOf()
         }

--- a/app/src/main/res/layout/fragment_transport.xml
+++ b/app/src/main/res/layout/fragment_transport.xml
@@ -7,7 +7,7 @@
     tools:context=".ui.transport.TransportFragment">
 
     <androidx.fragment.app.FragmentContainerView xmlns:map="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/fcb_map"
+        android:id="@+id/fcv_map"
         android:name="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -15,6 +15,9 @@
         <action
             android:id="@+id/action_transportFragment_to_transportVolFragment"
             app:destination="@id/transportVolFragment" />
+        <action
+            android:id="@+id/action_transportFragment_to_transportListsFragment"
+            app:destination="@id/transportListsFragment" />
     </fragment>
     <fragment
         android:id="@+id/adoptFragment"


### PR DESCRIPTION
### 아키텍쳐 적용
- 세그먼티드 버튼으로 구성된 요청자와 봉사자 버튼을 통해서 각각에 해당하는 데이터를 서버에서 불러와 지도에 마커와 클러스터로 표시하였습니다.
  - 요청자와 봉사자를 구분해서 표시하는 방법은 아래와 같이 3가지 방법이 있습니다. 현재는 첫 번째 방법으로 구현했습니다. 그러나 팀 회의 후에 더 좋은 방법이 있다면 그 방법으로 구현했으면 합니다.
    - 구분이 필요한 함수에 모두 조건문을 사용하여 구분하기
    - 한 번만 조건문을 사용하고 필요한 함수를 각각에 맞게 두 번씩 사용하기
    - 두개의 프래그먼트를 사용하여 각각 사용하기  
- 같은 위치의 마커를 모두 지도상에 나타내기 위해 중복된 위치는 랜덤으로 가까운 다른 곳으로 위치시켜 모든 마커가 표시되도록 구현했습니다. 하지만 이렇게 구현하면 화면의 이동이 발생할 때마다 마커의 위치가 랜덤으로 지정되므로 좋지 않은 것 같습니다. 팀 회의에서 더 논의해서 좋은 방법을 찾으면 좋겟습니다. 
- 줌 레벨에 따른 마커와 클러스터의 행동을 정하는 로직을 수정하여 클러스터 안에 클러스터가 있을 경우와, 다른 화면으로 이동을 위한 기준 줌 레벨 보다 더 줌이 되었을 경우에 대비했습니다.
  - 클러스터 안에 클러스터 : 클러스터를 한 번 더 클릭하여 줌이 되고 클러스터가 마커로 분리되도록 구현
  - 이동이 발생하는 줌 레벨 보다 더 줌이 된 경우 : 기존엔 마커가 중심이 되도록 지도가 움직이는 것이었으나 다른 화면으로 이동하도록 구현 하였습니다. 이것도 어느 방법이 더 좋은지 논의했으면 합니다. 