### PR TITLE
닉네임 중복확인 기능을 구현했습니다. 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:name=".ui.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustPan">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/teamtriad/forpets/data/UserRepository.kt
+++ b/app/src/main/java/com/teamtriad/forpets/data/UserRepository.kt
@@ -28,6 +28,20 @@ class UserRepository(private val databaseService: RemoteDatabaseService) {
         return null
     }
 
+    suspend fun getUsersMap(): Map<String, User>? {
+        try {
+            val response = databaseService.getUsersMap()
+
+            if (response.isSuccessful) {
+                return response.body()
+            }
+        } catch (e: Exception) {
+            Log.e("UserRepository", e.message.toString())
+        }
+
+        return null
+    }
+
     suspend fun getUserNicknameByUid(uid: String): String? {
         try {
             val response = databaseService.getUserNicknameByUid(uid)

--- a/app/src/main/java/com/teamtriad/forpets/data/source/network/RemoteDatabaseService.kt
+++ b/app/src/main/java/com/teamtriad/forpets/data/source/network/RemoteDatabaseService.kt
@@ -114,6 +114,9 @@ interface RemoteDatabaseService {
         @Body user: User
     ): Response<Unit>
 
+    @GET("user.json")
+    suspend fun getUsersMap(): Response<Map<String, User>>
+
     @GET("user/{uid}.json")
     suspend fun getUserByUid(
         @Path("uid") uid: String

--- a/app/src/main/java/com/teamtriad/forpets/data/source/network/model/User.kt
+++ b/app/src/main/java/com/teamtriad/forpets/data/source/network/model/User.kt
@@ -7,6 +7,5 @@ data class User(
     val email: String,
     val password: String,
     val nickname: String,
-    val phone: String,
     val token: String,
 )

--- a/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpIndividualFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpIndividualFragment.kt
@@ -39,6 +39,8 @@ class SignUpIndividualFragment : Fragment() {
     private var isValidEmail = false
     private lateinit var authCode: String
     private lateinit var userEmail: String
+    private lateinit var nickname: String
+    private lateinit var password: String
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -117,6 +119,7 @@ class SignUpIndividualFragment : Fragment() {
                         btnVerifyNickname.visibility = View.GONE
                         btnVerifiedNickname.visibility = View.VISIBLE
                         tilNickname.error = null
+                        nickname = tietNickname.text.toString()
                     }
                 }
             }

--- a/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpIndividualFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpIndividualFragment.kt
@@ -9,12 +9,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import com.teamtriad.forpets.BuildConfig.EMAIL_ADDRESS
 import com.teamtriad.forpets.BuildConfig.EMAIL_PASSOWRD
 import com.teamtriad.forpets.R
 import com.teamtriad.forpets.databinding.FragmentSignUpIndividualBinding
 import com.teamtriad.forpets.util.setSafeOnClickListener
+import com.teamtriad.forpets.viewmodel.ProfileViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -27,6 +30,8 @@ import javax.mail.internet.InternetAddress
 import javax.mail.internet.MimeMessage
 
 class SignUpIndividualFragment : Fragment() {
+
+    private val viewModel: ProfileViewModel by activityViewModels()
 
     private var _binding: FragmentSignUpIndividualBinding? = null
     private val binding get() = _binding!!
@@ -48,6 +53,7 @@ class SignUpIndividualFragment : Fragment() {
         setOnClickListener()
         checkEmailAddress()
         checkAuthCode()
+        checkUserNickname()
     }
 
     private fun setOnClickListener() = with(binding) {
@@ -92,6 +98,27 @@ class SignUpIndividualFragment : Fragment() {
                     R.string.sign_up_auth_code_not_valid,
                     Snackbar.LENGTH_LONG
                 ).show()
+            }
+        }
+
+        btnVerifyNickname.setSafeOnClickListener {
+            lifecycleScope.launch {
+                viewModel.getUsersMap().join()
+                val userNicknameList = mutableListOf<String>()
+                viewModel.usersMap?.values?.forEach { userNicknameList.add(it.nickname) }
+                if (userNicknameList.contains(binding.tietNickname.text.toString())) {
+                    with(binding) {
+                        btnVerifyNickname.visibility = View.VISIBLE
+                        btnVerifiedNickname.visibility = View.GONE
+                        tilNickname.error = getString(R.string.sign_up_nickname_error_message)
+                    }
+                } else {
+                    with(binding) {
+                        btnVerifyNickname.visibility = View.GONE
+                        btnVerifiedNickname.visibility = View.VISIBLE
+                        tilNickname.error = null
+                    }
+                }
             }
         }
     }
@@ -177,6 +204,37 @@ class SignUpIndividualFragment : Fragment() {
                     btnAuthenticate.apply {
                         isEnabled = false
                         isClickable = false
+                    }
+                }
+            }
+        })
+    }
+
+    private fun checkUserNickname() = with(binding) {
+        tietNickname.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+                val pattern = Regex("[가-힣a-zA-Z0-9]{2,}")
+                if (pattern.matches(s.toString())) {
+                    btnVerifyNickname.apply {
+                        isEnabled = true
+                        isClickable = true
+                        btnVerifyNickname.visibility = View.VISIBLE
+                        btnVerifiedNickname.visibility = View.GONE
+                        tilNickname.error = null
+                    }
+                } else {
+                    btnVerifyNickname.apply {
+                        isEnabled = false
+                        isClickable = false
+                        btnVerifyNickname.visibility = View.VISIBLE
+                        btnVerifiedNickname.visibility = View.GONE
+                        tilNickname.error = null
                     }
                 }
             }

--- a/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpUserFragment.kt
+++ b/app/src/main/java/com/teamtriad/forpets/ui/login/SignUpUserFragment.kt
@@ -84,7 +84,7 @@ class SignUpUserFragment : Fragment() {
 
         auth!!.createUserWithEmailAndPassword(email, password).addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                val user = User(email, password, nickname, "", "")
+                val user = User(email, password, nickname, "")
                 saveUserDataToDatabase(user)
             } else {
                 handleRegistrationFailure(task)

--- a/app/src/main/java/com/teamtriad/forpets/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/teamtriad/forpets/viewmodel/ProfileViewModel.kt
@@ -11,6 +11,9 @@ class ProfileViewModel : ViewModel() {
 
     private val userRepository = UserRepository(remoteDatabaseService)
 
+    private var _usersMap: Map<String, User>? = null
+    val usersMap get() = _usersMap
+
     fun addUserByUid(uid: String, user: User) {
         viewModelScope.launch {
             userRepository.addUserByUid(uid, user)
@@ -20,6 +23,11 @@ class ProfileViewModel : ViewModel() {
     suspend fun getUserByUid(uid: String): User? {
         return userRepository.getUserByUid(uid)
     }
+
+    fun getUsersMap() = viewModelScope.launch {
+            _usersMap = userRepository.getUsersMap()
+        }
+
 
     suspend fun getUserNicknameByUid(uid: String): String? {
         return userRepository.getUserNicknameByUid(uid)

--- a/app/src/main/res/layout/fragment_sign_up_individual.xml
+++ b/app/src/main/res/layout/fragment_sign_up_individual.xml
@@ -125,16 +125,32 @@
             app:layout_constraintEnd_toEndOf="@id/til_nickname"
             app:layout_constraintTop_toBottomOf="@id/til_nickname" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_verified_nickname"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:backgroundTint="@android:color/holo_green_dark"
+            android:clickable="false"
+            android:enabled="false"
+            android:text="@string/sign_up_btn_available_nickname"
+            android:textColor="@color/white"
+            android:visibility="gone"
+            app:icon="@drawable/ic_check"
+            app:iconTint="@color/white"
+            app:layout_constraintEnd_toEndOf="@id/til_nickname"
+            app:layout_constraintTop_toBottomOf="@id/til_nickname" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/til_password"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="22dp"
+            android:layout_marginTop="70dp"
             android:hint="@string/all_til_password_hint"
             app:endIconMode="password_toggle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_verify_nickname">
+            app:layout_constraintTop_toBottomOf="@id/til_nickname">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/tiet_password"

--- a/app/src/main/res/layout/fragment_sign_up_individual.xml
+++ b/app/src/main/res/layout/fragment_sign_up_individual.xml
@@ -67,7 +67,7 @@
             android:id="@+id/btn_authenticate"
             android:layout_width="150dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="20dp"
             android:backgroundTint="@color/selector_button_background_color"
             android:clickable="false"
             android:enabled="false"
@@ -112,16 +112,29 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_verify_nickname"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/selector_button_background_color"
+            android:layout_marginTop="1dp"
+            android:clickable="false"
+            android:enabled="false"
+            android:text="@string/sign_up_btn_verify_nickname"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="@id/til_nickname"
+            app:layout_constraintTop_toBottomOf="@id/til_nickname" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/til_password"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="50dp"
+            android:layout_marginTop="22dp"
             android:hint="@string/all_til_password_hint"
             app:endIconMode="password_toggle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/til_nickname">
+            app:layout_constraintTop_toBottomOf="@id/btn_verify_nickname">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/tiet_password"
@@ -154,7 +167,7 @@
             android:id="@+id/btn_post"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="80dp"
+            android:layout_marginTop="50dp"
             android:layout_marginBottom="13dp"
             android:backgroundTint="@color/selector_button_background_color"
             android:clickable="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,5 +148,7 @@
     <string name="sign_up_email_title">도와줘멍냥 회원가입 인증번호입니다.</string>
     <string name="sign_up_email_message">\n\n안녕하세요. 도와줘멍냥입니다!\n\n아래 인증번호를 인증창에 입력해주세요.\n\n인증번호 : %s</string>
     <string name="sign_up_btn_verify_nickname">중복 확인하기</string>
+    <string name="sign_up_nickname_error_message">이미 존재하는 닉네임입니다. 다른 닉네임을 입력해 주세요!</string>
+    <string name="sign_up_btn_available_nickname">사용가능</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,5 +147,6 @@
     <string name="sign_up_auth_code_not_valid">인증번호를 확인해 주세요!</string>
     <string name="sign_up_email_title">도와줘멍냥 회원가입 인증번호입니다.</string>
     <string name="sign_up_email_message">\n\n안녕하세요. 도와줘멍냥입니다!\n\n아래 인증번호를 인증창에 입력해주세요.\n\n인증번호 : %s</string>
+    <string name="sign_up_btn_verify_nickname">중복 확인하기</string>
 
 </resources>


### PR DESCRIPTION
### 닉네임 유효성 검사
- 닉네임은 한글, 영문자(대문자, 소문자) 그리고 숫자만 사용할 수 있도록 정규식을 활용해 구현함.
- 위의 조건대로 2글자 이상 입력되면 '중복 확인하기' 버튼이 활성화 되도록 구현함.

### 닉네임 중복확인
- '중복 확인하기' 버튼을 클릭하면 리얼타임데이터베이스에 저장된 데이터와 비교하여 중복 여부를 검사.
  - 중복된 경우 : 오류 메시지
  - 중복되지 않은 경우 : '중복 확인하기' 버튼 -> '사용가능' 버튼
- '사용가능' 버튼 상태에서 닉네임 변경시 : '사용가능' 버튼 -> '중복 확인하기' 버튼
- 중복되어 오류 메시지가 있는 상태에서 닉네임 변경시 : 오류 메시지 없어짐